### PR TITLE
Got rid of v1 in module path to make it go-gettable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Go client library for accessing the [Clerk Server API v1](https://docs.clerk.dev
 First, add one of the following imports, depending on whether you use modules or not.
 
 ```go
-import "github.com/clerkinc/clerk_server_sdk_go/v1/clerk" // with go modules enabled
-import "github.com/clerkinc/clerk_server_sdk_go/clerk"    // with go modules disabled
+import "github.com/clerkinc/clerk_server_sdk_go/clerk" // with go modules enabled
 ```
 
 Now, you can create a Clerk client by calling the `clerk.NewClient` function.

--- a/example/main.go
+++ b/example/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/clerkinc/clerk_server_sdk_go/v1/clerk"
+	"github.com/clerkinc/clerk_server_sdk_go/clerk"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/clerkinc/clerk_server_sdk_go/v1
+module github.com/clerkinc/clerk_server_sdk_go
 
 go 1.15

--- a/tests/integration/clerk_test.go
+++ b/tests/integration/clerk_test.go
@@ -3,7 +3,7 @@
 package integration
 
 import (
-	"github.com/clerkinc/clerk_server_sdk_go/v1/clerk"
+	"github.com/clerkinc/clerk_server_sdk_go/clerk"
 	"os"
 )
 

--- a/tests/integration/emails_test.go
+++ b/tests/integration/emails_test.go
@@ -3,7 +3,7 @@
 package integration
 
 import (
-	"github.com/clerkinc/clerk_server_sdk_go/v1/clerk"
+	"github.com/clerkinc/clerk_server_sdk_go/clerk"
 	"reflect"
 	"testing"
 )

--- a/tests/integration/sms_test.go
+++ b/tests/integration/sms_test.go
@@ -3,7 +3,7 @@
 package integration
 
 import (
-	"github.com/clerkinc/clerk_server_sdk_go/v1/clerk"
+	"github.com/clerkinc/clerk_server_sdk_go/clerk"
 	"testing"
 )
 

--- a/tests/integration/users_test.go
+++ b/tests/integration/users_test.go
@@ -3,7 +3,7 @@
 package integration
 
 import (
-	"github.com/clerkinc/clerk_server_sdk_go/v1/clerk"
+	"github.com/clerkinc/clerk_server_sdk_go/clerk"
 	"testing"
 )
 


### PR DESCRIPTION
# Title

<!--- Provide a general summary of your changes in the Title above -->

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Because we're still in version 1, we need to get rid of the version in the module path according to this: https://golang.org/ref/mod#major-version-suffixes

That was the reason I couldn't add the SDK as a dependency in the `clerk_go` project.

### Related Issue (optional)

<!--- Please link to the issue here: -->
